### PR TITLE
make service_account.automount_service_account_token configurable

### DIFF
--- a/kubernetes/resource_kubernetes_service_account.go
+++ b/kubernetes/resource_kubernetes_service_account.go
@@ -28,6 +28,12 @@ func resourceKubernetesServiceAccount() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("service account", true),
+			"automount_service_account_token": {
+				Type:        schema.TypeBool,
+				Description: "AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.",
+				Optional:    true,
+				Default:     false,
+			},
 			"image_pull_secret": {
 				Type:        schema.TypeSet,
 				Description: "A list of references to secrets in the same namespace to use for pulling any images in pods that reference this Service Account. More info: http://kubernetes.io/docs/user-guide/secrets#manually-specifying-an-imagepullsecret",
@@ -69,7 +75,7 @@ func resourceKubernetesServiceAccountCreate(d *schema.ResourceData, meta interfa
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
 	svcAcc := api.ServiceAccount{
-		AutomountServiceAccountToken: ptrToBool(false),
+		AutomountServiceAccountToken: ptrToBool(d.Get("automount_service_account_token").(bool)),
 		ObjectMeta:                   metadata,
 		ImagePullSecrets:             expandLocalObjectReferenceArray(d.Get("image_pull_secret").(*schema.Set).List()),
 		Secrets:                      expandServiceAccountSecrets(d.Get("secret").(*schema.Set).List(), ""),
@@ -144,6 +150,7 @@ func resourceKubernetesServiceAccountRead(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+	d.Set("automount_service_account_token", svcAcc.AutomountServiceAccountToken)
 	d.Set("image_pull_secret", flattenLocalObjectReferenceArray(svcAcc.ImagePullSecrets))
 
 	defaultSecretName := d.Get("default_secret_name").(string)
@@ -164,6 +171,13 @@ func resourceKubernetesServiceAccountUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	ops := patchMetadata("metadata.0.", "/metadata/", d)
+	if d.HasChange("automount_service_account_token") {
+		v := d.Get("automount_service_account_token")
+		ops = append(ops, &ReplaceOperation{
+			Path:  "/automountServiceAccountToken",
+			Value: v,
+		})
+	}
 	if d.HasChange("image_pull_secret") {
 		v := d.Get("image_pull_secret").(*schema.Set).List()
 		ops = append(ops, &ReplaceOperation{

--- a/kubernetes/resource_kubernetes_service_account_test.go
+++ b/kubernetes/resource_kubernetes_service_account_test.go
@@ -41,6 +41,7 @@ func TestAccKubernetesServiceAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "false"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "secret.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "image_pull_secret.#", "2"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{
@@ -86,6 +87,7 @@ func TestAccKubernetesServiceAccount_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "false"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "secret.#", "2"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "image_pull_secret.#", "2"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{
@@ -116,6 +118,7 @@ func TestAccKubernetesServiceAccount_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "true"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "secret.#", "1"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "image_pull_secret.#", "3"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{
@@ -141,6 +144,7 @@ func TestAccKubernetesServiceAccount_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "false"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "secret.#", "0"),
 					resource.TestCheckResourceAttr("kubernetes_service_account.test", "image_pull_secret.#", "0"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{}),
@@ -177,9 +181,44 @@ func TestAccKubernetesServiceAccount_generatedName(t *testing.T) {
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
 					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "false"),
 					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{}),
 					testAccCheckServiceAccountSecrets(&conf, []*regexp.Regexp{
 						regexp.MustCompile("^" + prefix + "[a-z0-9]+-token-[a-z0-9]+$"),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKubernetesServiceAccount_automountServiceAccountToken(t *testing.T) {
+	var conf api.ServiceAccount
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "kubernetes_service_account.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckKubernetesServiceAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesServiceAccountConfig_automountServiceAccountToken(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKubernetesServiceAccountExists("kubernetes_service_account.test", &conf),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "metadata.0.annotations.%", "0"),
+					testAccCheckMetaAnnotations(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "metadata.0.labels.%", "0"),
+					testAccCheckMetaLabels(&conf.ObjectMeta, map[string]string{}),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "metadata.0.name", name),
+					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.generation"),
+					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.resource_version"),
+					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.self_link"),
+					resource.TestCheckResourceAttrSet("kubernetes_service_account.test", "metadata.0.uid"),
+					resource.TestCheckResourceAttr("kubernetes_service_account.test", "automount_service_account_token", "true"),
+					testAccCheckServiceAccountImagePullSecrets(&conf, []*regexp.Regexp{}),
+					testAccCheckServiceAccountSecrets(&conf, []*regexp.Regexp{
+						regexp.MustCompile("^" + name + "-token-[a-z0-9]+$"),
 					}),
 				),
 			},
@@ -345,6 +384,7 @@ resource "kubernetes_secret" "four" {
 func testAccKubernetesServiceAccountConfig_modified(name string) string {
 	return fmt.Sprintf(`
 resource "kubernetes_service_account" "test" {
+        automount_service_account_token = true
 	metadata {
 		annotations {
 			TestAnnotationOne = "one"
@@ -412,4 +452,14 @@ resource "kubernetes_service_account" "test" {
 		generate_name = "%s"
 	}
 }`, prefix)
+}
+
+func testAccKubernetesServiceAccountConfig_automountServiceAccountToken(name string) string {
+	return fmt.Sprintf(`
+resource "kubernetes_service_account" "test" {
+        automount_service_account_token = true
+	metadata {
+		name = "%s"
+	}
+}`, name)
 }


### PR DESCRIPTION
@immuta/developers 

The current behavior of the service account resource is to set `automountServiceAccountToken` to false. This doesn't work well for helm installs and things of that nature where you cannot override that value. It is also different from the default kubectl behavior. This adds an optional parameter `automount_service_account_token` that defaults to false, but can be set to true.