### PR TITLE
Add use_default_provisioning flag to persistent_volume_claim

### DIFF
--- a/kubernetes/resource_kubernetes_persistent_volume_claim.go
+++ b/kubernetes/resource_kubernetes_persistent_volume_claim.go
@@ -39,7 +39,12 @@ func resourceKubernetesPersistentVolumeClaimCreate(d *schema.ResourceData, meta 
 	conn := meta.(*kubernetesProvider).conn
 
 	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	spec, err := expandPersistentVolumeClaimSpec(d.Get("spec").([]interface{}))
+
+	use_default_provisioning := false
+	if v, ok := d.GetOk("use_default_provisioning"); ok {
+		use_default_provisioning = v.(bool)
+	}
+	spec, err := expandPersistentVolumeClaimSpec(d.Get("spec").([]interface{}), use_default_provisioning)
 	if err != nil {
 		return err
 	}
@@ -122,6 +127,7 @@ func resourceKubernetesPersistentVolumeClaimRead(d *schema.ResourceData, meta in
 	if err != nil {
 		return err
 	}
+
 	err = d.Set("spec", flattenPersistentVolumeClaimSpec(claim.Spec))
 	if err != nil {
 		return err

--- a/kubernetes/resource_kubernetes_stateful_set_test.go
+++ b/kubernetes/resource_kubernetes_stateful_set_test.go
@@ -232,9 +232,6 @@ resource "kubernetes_stateful_set" "test" {
 		volume_claim_templates {
 			metadata {
 				name = "pvc"
-				annotations {
-					"volume.alpha.kubernetes.io/storage-class" =  "anything"
-				}
 			}
 			spec {
 				access_modes = ["ReadWriteOnce"]

--- a/kubernetes/schema_persistent_volume_claim_spec.go
+++ b/kubernetes/schema_persistent_volume_claim_spec.go
@@ -108,6 +108,12 @@ func persistentVolumeClaimSpecFields(pvcTemplate bool) map[string]*schema.Schema
 				},
 			},
 		},
+		"use_default_provisioning": {
+			Type:        schema.TypeBool,
+			Description: "Set to true to allow the cluster to determine what storage class to use. Setting spec.storage_class_name will override this.",
+			Optional:    true,
+			Default:     true,
+		},
 		"wait_until_bound": {
 			Type:        schema.TypeBool,
 			Description: "Whether to wait for the claim to reach `Bound` state (to find volume in which to claim the space)",

--- a/kubernetes/structure_persistent_volume_claim.go
+++ b/kubernetes/structure_persistent_volume_claim.go
@@ -36,7 +36,7 @@ func flattenResourceRequirements(in v1.ResourceRequirements) []interface{} {
 
 // Expanders
 
-func expandPersistentVolumeClaimSpec(l []interface{}) (v1.PersistentVolumeClaimSpec, error) {
+func expandPersistentVolumeClaimSpec(l []interface{}, use_default_provisioning bool) (v1.PersistentVolumeClaimSpec, error) {
 	if len(l) == 0 || l[0] == nil {
 		return v1.PersistentVolumeClaimSpec{}, nil
 	}
@@ -55,7 +55,7 @@ func expandPersistentVolumeClaimSpec(l []interface{}) (v1.PersistentVolumeClaimS
 	if v, ok := in["volume_name"].(string); ok {
 		obj.VolumeName = v
 	}
-	if v, ok := in["storage_class_name"].(string); ok {
+	if v, ok := in["storage_class_name"].(string); ok && !use_default_provisioning {
 		obj.StorageClassName = ptrToString(v)
 	}
 	return obj, nil


### PR DESCRIPTION
This fixes an issue with persistent volume claims. Previously you could not set `storage_class_name` to the empty string (which effectively disables dynamic provisioning using the default storage class).

This adds a flag `use_default_provisioning` that, when set to `true`, will allow `storage_class_name` to be set to an empty string.